### PR TITLE
sci_mscanf.cpp: PVS-Studio: CWE-252: Unchecked Return Value.

### DIFF
--- a/scilab/modules/fileio/sci_gateway/cpp/sci_mscanf.cpp
+++ b/scilab/modules/fileio/sci_gateway/cpp/sci_mscanf.cpp
@@ -271,7 +271,7 @@ types::Function::ReturnValue sci_mscanf(types::typed_list &in, int _iRetCount, t
                                 {
                                     pType->set(iRows * iCols + k, pIT[i]->getAs<types::Double>()->get(k));
                                 }
-                                pITTemp.back();
+                                pITTemp.pop_back();
                                 pITTemp.push_back(pType);
                             }
                             break;


### PR DESCRIPTION
We have found and fixed a weakness  using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) analyzer. 

Analyzer warning: [V530](https://www.viva64.com/en/w/V530/) The return value of function 'back' is required to be utilized.