### PR TITLE
sci_model2blk.cpp: PVS-Studio: CWE-476 NULL Pointer Dereference.

### DIFF
--- a/scilab/modules/scicos/sci_gateway/cpp/sci_model2blk.cpp
+++ b/scilab/modules/scicos/sci_gateway/cpp/sci_model2blk.cpp
@@ -476,7 +476,7 @@ types::Function::ReturnValue sci_model2blk(types::typed_list &in, int _iRetCount
             }
 
             Block.inptr[i] = MALLOC(size);
-            if (Block.inptr == nullptr)
+            if (Block.inptr[i] == nullptr)
             {
                 freeBlock(&Block);
                 Scierror(888, _("%s : Allocation error.\n"), name.data());


### PR DESCRIPTION
We have found and fixed a weakness  using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) analyzer. 

Analyzer warning: [V595](https://www.viva64.com/en/w/V595/) The 'Block.inptr' pointer was utilized before it was verified against nullptr.