### PR TITLE
diary_manager.cpp: PVS-Studio: CWE-476 NULL Pointer Dereference.

### DIFF
--- a/scilab/modules/output_stream/src/cpp/diary_manager.cpp
+++ b/scilab/modules/output_stream/src/cpp/diary_manager.cpp
@@ -65,7 +65,7 @@ wchar_t **getDiaryFilenames(int *array_size)
     {
         std::list<std::wstring> wstringFilenames = SCIDIARY->getFilenames();
         *array_size = (int)wstringFilenames.size();
-        if (array_size > 0)
+        if (*array_size > 0)
         {
             wchar_t **wcFilenames = (wchar_t **) MALLOC (sizeof(wchar_t*) * (*array_size));
             int i = 0;


### PR DESCRIPTION
We have found and fixed a weakness  using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) analyzer. 

Analyzer warning: [V595](https://www.viva64.com/en/w/V595/) The 'array_size' pointer was utilized before it was verified against nullptr. 